### PR TITLE
allow providing a HTML template for typeahead

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+[*]
+end_of_line = crlf
+indent_size=4
+indent_style=space

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Please check our documentation for installation details and the reference manual
 
 ### Release Notes
 
+#### 0.1.20
+Custom HTML templates for typeahead.
+
 #### 0.1.19
 Assign id to typeahead's input. This will allow you to use a label <strong>for</strong> attribute with a typeahead.
 

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -4,6 +4,7 @@ var to5 = require('gulp-babel');
 var paths = require('../paths');
 var compilerOptions = require('../babel-options');
 var assign = Object.assign || require('object.assign');
+var lec = require('gulp-line-ending-corrector');
 
 gulp.task('build-html', function () {
   return gulp.src(paths.html)
@@ -16,24 +17,28 @@ gulp.task('build-html', function () {
 gulp.task('build-es2015', function () {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.es2015())))
+    .pipe(lec({ eolc: 'CRLF' }))
     .pipe(gulp.dest(paths.output + 'es2015'));
 });
 
 gulp.task('build-commonjs', function () {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.commonjs())))
+    .pipe(lec({ eolc: 'CRLF' }))
     .pipe(gulp.dest(paths.output + 'commonjs'));
 });
 
 gulp.task('build-amd', function () {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.amd())))
+    .pipe(lec({ eolc: 'CRLF' }))
     .pipe(gulp.dest(paths.output + 'amd'));
 });
 
 gulp.task('build-system', function () {
   return gulp.src(paths.source)
     .pipe(to5(assign({}, compilerOptions.system())))
+    .pipe(lec({ eolc: 'CRLF' }))
     .pipe(gulp.dest(paths.output + 'system'));
 });
 

--- a/dist/amd/typeahead/aubs-typeahead.html
+++ b/dist/amd/typeahead/aubs-typeahead.html
@@ -16,21 +16,26 @@
             </li>
 
             <li repeat.for="item of displayData" show.bind="!loading" class.bind="focusedItem === item ? 'active' : ''">
-                <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
-                   innerhtml.bind="getName(item) | typeaheadHighlight:filter">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter">
 
-                </a>
+                    </a>
+                </template>              
             </li>
         </ul>
 
         <div class="dropdown-menu" if.bind="v4">
             <h6 class="dropdown-header text-center" show.bind="displayData.length == 0 && !loading" innerhtml.bind="noResultsText"></h6>
             <h6 class="dropdown-header text-center" show.bind="loading" innerhtml.bind="loadingText"></h6>
-
-            <a repeat.for="item of displayData" class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
-               show.bind="!loading" click.delegate="itemSelected(item)"
-               innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
-
+            
+            <template repeat.for="item of displayData">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
+                     show.bind="!loading" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
+                </template>
+            </template>            
         </div>
     </div>
 </template>

--- a/dist/commonjs/typeahead/aubs-typeahead.html
+++ b/dist/commonjs/typeahead/aubs-typeahead.html
@@ -16,21 +16,26 @@
             </li>
 
             <li repeat.for="item of displayData" show.bind="!loading" class.bind="focusedItem === item ? 'active' : ''">
-                <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
-                   innerhtml.bind="getName(item) | typeaheadHighlight:filter">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter">
 
-                </a>
+                    </a>
+                </template>              
             </li>
         </ul>
 
         <div class="dropdown-menu" if.bind="v4">
             <h6 class="dropdown-header text-center" show.bind="displayData.length == 0 && !loading" innerhtml.bind="noResultsText"></h6>
             <h6 class="dropdown-header text-center" show.bind="loading" innerhtml.bind="loadingText"></h6>
-
-            <a repeat.for="item of displayData" class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
-               show.bind="!loading" click.delegate="itemSelected(item)"
-               innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
-
+            
+            <template repeat.for="item of displayData">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
+                     show.bind="!loading" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
+                </template>
+            </template>            
         </div>
     </div>
 </template>

--- a/dist/es2015/typeahead/aubs-typeahead.html
+++ b/dist/es2015/typeahead/aubs-typeahead.html
@@ -16,21 +16,26 @@
             </li>
 
             <li repeat.for="item of displayData" show.bind="!loading" class.bind="focusedItem === item ? 'active' : ''">
-                <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
-                   innerhtml.bind="getName(item) | typeaheadHighlight:filter">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter">
 
-                </a>
+                    </a>
+                </template>              
             </li>
         </ul>
 
         <div class="dropdown-menu" if.bind="v4">
             <h6 class="dropdown-header text-center" show.bind="displayData.length == 0 && !loading" innerhtml.bind="noResultsText"></h6>
             <h6 class="dropdown-header text-center" show.bind="loading" innerhtml.bind="loadingText"></h6>
-
-            <a repeat.for="item of displayData" class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
-               show.bind="!loading" click.delegate="itemSelected(item)"
-               innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
-
+            
+            <template repeat.for="item of displayData">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
+                     show.bind="!loading" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
+                </template>
+            </template>            
         </div>
     </div>
 </template>

--- a/dist/system/typeahead/aubs-typeahead.html
+++ b/dist/system/typeahead/aubs-typeahead.html
@@ -16,21 +16,26 @@
             </li>
 
             <li repeat.for="item of displayData" show.bind="!loading" class.bind="focusedItem === item ? 'active' : ''">
-                <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
-                   innerhtml.bind="getName(item) | typeaheadHighlight:filter">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter">
 
-                </a>
+                    </a>
+                </template>              
             </li>
         </ul>
 
         <div class="dropdown-menu" if.bind="v4">
             <h6 class="dropdown-header text-center" show.bind="displayData.length == 0 && !loading" innerhtml.bind="noResultsText"></h6>
             <h6 class="dropdown-header text-center" show.bind="loading" innerhtml.bind="loadingText"></h6>
-
-            <a repeat.for="item of displayData" class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
-               show.bind="!loading" click.delegate="itemSelected(item)"
-               innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
-
+            
+            <template repeat.for="item of displayData">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
+                     show.bind="!loading" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
+                </template>
+            </template>            
         </div>
     </div>
 </template>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-bootstrap",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Bootstrap components written in Aurelia.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gulp-bump": "^2.2.0",
     "gulp-eslint": "^3.0.1",
     "gulp-yuidoc": "^0.1.2",
+    "gulp-line-ending-corrector": "1.0.1" ,
     "isparta": "^4.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "jasmine-core": "^2.4.1",

--- a/src/typeahead/aubs-typeahead.html
+++ b/src/typeahead/aubs-typeahead.html
@@ -16,21 +16,26 @@
             </li>
 
             <li repeat.for="item of displayData" show.bind="!loading" class.bind="focusedItem === item ? 'active' : ''">
-                <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
-                   innerhtml.bind="getName(item) | typeaheadHighlight:filter">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item" href="javascript:void(0)" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter">
 
-                </a>
+                    </a>
+                </template>              
             </li>
         </ul>
 
         <div class="dropdown-menu" if.bind="v4">
             <h6 class="dropdown-header text-center" show.bind="displayData.length == 0 && !loading" innerhtml.bind="noResultsText"></h6>
             <h6 class="dropdown-header text-center" show.bind="loading" innerhtml.bind="loadingText"></h6>
-
-            <a repeat.for="item of displayData" class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
-               show.bind="!loading" click.delegate="itemSelected(item)"
-               innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
-
+            
+            <template repeat.for="item of displayData">
+                <template part="item-template" replaceable>
+                    <a class="dropdown-item ${focusedItem === item  ? 'active' : ''}" href="javascript:void(0)"
+                     show.bind="!loading" click.delegate="itemSelected(item)"
+                     innerhtml.bind="getName(item) | typeaheadHighlight:filter"></a>
+                </template>
+            </template>            
         </div>
     </div>
 </template>


### PR DESCRIPTION
Hi, and thanks for the great library! We have the need to provide a custom HTML template, instead of a simple string, for typeahead. For this, I added replaceable template parts, similar to https://gist.github.com/jdanyow/acf8253329939b2e046cd0e3394351fe . It should be backwards compatible. I tried testing it with both Bootstrap 3 and 4. Still a bit of a Aurelia noob, so let me know if I did something wrong.