### PR TITLE
Fix #28 (tooltip and popover re-attaching issue)

### DIFF
--- a/src/popover/aubs-popover.js
+++ b/src/popover/aubs-popover.js
@@ -55,7 +55,7 @@ export class AubsPopoverCustomAttribute {
             this.customPopover.style.display = 'none';
         }
 
-        this.attached = true;
+        this.isAttached = true;
         if (this.isOpen) {
             this.handleShow();
         }
@@ -78,7 +78,7 @@ export class AubsPopoverCustomAttribute {
     }
 
     isOpenChanged() {
-        if (!this.attached) {
+        if (!this.isAttached) {
             return;
         }
 

--- a/src/tooltip/aubs-tooltip.js
+++ b/src/tooltip/aubs-tooltip.js
@@ -43,7 +43,7 @@ export class AubsTooltipCustomAttribute {
     attached() {
         this.tooltipService.setTriggers(this.element, this.triggers, this.listeners);
 
-        this.attached = true;
+        this.isAttached = true;
         if (this.open) {
             this.handleShow();
         }
@@ -62,7 +62,7 @@ export class AubsTooltipCustomAttribute {
     }
 
     openChanged() {
-        if (!this.attached) {
+        if (!this.isAttached) {
             return;
         }
 


### PR DESCRIPTION
I found some time to check the issue myself, and it turns out it was really easy.
In most custom attributes, there's a variable used to know if the element is attached or not, and it's called `isAttached`...

However, in popovers and tooltips, it was called `attached`, thus overriding the function itself and preventing any further attach events. I made this PR real quick to fix the issue.